### PR TITLE
Change `bis` to `-` in German translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "2pv-vue-bulma-datepicker",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "description": "Datepicker Component for Vue Bulma",
   "main": "src/index.vue",
   "peerDependencies": {

--- a/src/index.vue
+++ b/src/index.vue
@@ -14,9 +14,9 @@ import WrapperInput from './WrapperInput'
 import Flatpickr from 'flatpickr'
 import de from 'flatpickr/src/l10n/de';
 
-const I18n = {
-  de: Object.assign({}, de.de, { rangeSeparator: " - " })
-};
+const I18n = { de: de.de };
+// see TPV-1973
+I18n.de.rangeSeparator = " - ";
 
 export default {
   mixins: [BasicInput],


### PR DESCRIPTION
IE11 doesn't support `Object.assign` so the previous method wouldn't work.

This approach is a little more like dealing with the issue with a sledgehammer but should work consistently.
